### PR TITLE
Honour the value of NSBaselineOffsetAttributeName

### DIFF
--- a/Core/Source/DTCoreTextLayoutFrame.m
+++ b/Core/Source/DTCoreTextLayoutFrame.m
@@ -1369,6 +1369,12 @@ static BOOL _DTCoreTextLayoutFramesShouldDrawDebugFrames = NO;
 					break;
 			}
 			
+			NSNumber *baselineOffset = oneRun.attributes[NSBaselineOffsetAttributeName];
+			if (baselineOffset)
+			{
+				textPosition.y += [baselineOffset floatValue];
+			}
+			
 			CGContextSetTextPosition(context, textPosition.x, textPosition.y);
 			
 			if (!oneRun.attachment)


### PR DESCRIPTION
Currently adding NSBaselineOffsetAttributeName to the attributes dictionary of the attributed string used to populate the DTAttributedTextContentView does not affect the position of the text.